### PR TITLE
Fix minor dart analysis problem (take 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.7] - 2018-10-19
+
+* Fix small analysis error.
+
 ## [0.0.6] - 2018-10-19
 
 * add countdown clock

--- a/lib/flip_panel.dart
+++ b/lib/flip_panel.dart
@@ -15,23 +15,24 @@ class FlipClock extends StatelessWidget {
   final FlipDirection flipDirection;
 
   /// Set countdown to true to have a countdown timer.
-  final bool countdown;
+  final bool countdownMode;
   final bool _showHours;
 
   /// Called when the countdown clock hits zero.
-  VoidCallback onDone;
+  final VoidCallback onDone;
 
   FlipClock({
     Key key,
     @required DigitBuilder digitBuilder,
     @required Widget separator,
     @required this.startTime,
-    this.countdown = false,
+    this.countdownMode = false,
     this.spacing = const EdgeInsets.symmetric(horizontal: 2.0),
     this.flipDirection = FlipDirection.up,
   })  : _showHours = true,
         _digitBuilder = digitBuilder,
-        _separator = separator;
+        _separator = separator,
+        onDone = null;
 
   FlipClock.simple({
     Key key,
@@ -42,8 +43,9 @@ class FlipClock extends StatelessWidget {
     BorderRadius borderRadius = const BorderRadius.all(Radius.circular(0.0)),
     this.spacing = const EdgeInsets.symmetric(horizontal: 2.0),
     this.flipDirection = FlipDirection.up,
-  })  : countdown = false,
-        _showHours = true {
+  })  : countdownMode = false,
+        _showHours = true,
+        onDone = null {
     _digitBuilder = (context, digit) => Container(
           alignment: Alignment.center,
           width: 44.0,
@@ -88,7 +90,7 @@ class FlipClock extends StatelessWidget {
     this.spacing = const EdgeInsets.symmetric(horizontal: 2.0),
     this.onDone,
     this.flipDirection = FlipDirection.up,
-  })  : countdown = true,
+  })  : countdownMode = true,
         startTime = DateTime(2018, 1, 0, 0, 0, duration.inSeconds),
         _showHours = duration.inHours > 0 {
     _digitBuilder = (context, digit) => Container(
@@ -132,11 +134,11 @@ class FlipClock extends StatelessWidget {
     final timeStream =
         Stream<DateTime>.periodic(Duration(milliseconds: 1000), (_) {
       var oldTime = time;
-      time = time.add(Duration(seconds: countdown ? -1 : 1));
+      time = time.add(Duration(seconds: countdownMode ? -1 : 1));
       if (oldTime.day != time.day) {
         time = oldTime;
         if (onDone != null) onDone();
-      } 
+      }
       return time;
     }).asBroadcastStream();
 
@@ -144,30 +146,32 @@ class FlipClock extends StatelessWidget {
     // TODO(efortuna): Instead, allow the user to specify the format of time instead.
     // Add hours if appropriate.
     if (_showHours) {
-      digitList.addAll([_buildSegment(timeStream, (DateTime time) => time.hour ~/ 10,
+      digitList.addAll([
+        _buildSegment(timeStream, (DateTime time) => time.hour ~/ 10,
             (DateTime time) => time.hour % 10, startTime),
-
         Padding(
           padding: spacing,
           child: _separator,
-        )]);
+        )
+      ]);
     }
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: digitList..addAll([
-        // Minutes
-        _buildSegment(timeStream, (DateTime time) => time.minute ~/ 10,
-            (DateTime time) => time.minute % 10, startTime),
+      children: digitList
+        ..addAll([
+          // Minutes
+          _buildSegment(timeStream, (DateTime time) => time.minute ~/ 10,
+              (DateTime time) => time.minute % 10, startTime),
 
-        Padding(
-          padding: spacing,
-          child: _separator,
-        ),
+          Padding(
+            padding: spacing,
+            child: _separator,
+          ),
 
-        // Seconds
-        _buildSegment(timeStream, (DateTime time) => time.second ~/ 10,
-            (DateTime time) => time.second % 10, startTime)
-      ]),
+          // Seconds
+          _buildSegment(timeStream, (DateTime time) => time.second ~/ 10,
+              (DateTime time) => time.second % 10, startTime)
+        ]),
     );
   }
 
@@ -200,7 +204,7 @@ class FlipClock extends StatelessWidget {
 
 /// Signature for a function that creates a widget for a given index, e.g., in a
 /// list.
-typedef Widget IndexedItemBuilder(BuildContext, int);
+typedef Widget IndexedItemBuilder(BuildContext, int );
 
 /// Signature for a function that creates a widget for a value emitted from a [Stream]
 typedef Widget StreamItemBuilder<T>(BuildContext, T);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flip_panel
 description: A package for flip panel with built-in animation
-version: 0.0.6
+version: 0.0.7
 author: hunghd <hunghd.yb@gmail.com>
 homepage: https://github.com/hnvn/flutter_flip_panel
 


### PR DESCRIPTION
I realized my previous PR accidentally introduced another analysis error (FlipClock.countdown() constructor and also a field called "countdown" so I changed it to "countdownMode"). Apologies! This PR fixes that. I also fixed a few other minor analysis warnings while I was there and then ran dartfmt.